### PR TITLE
feat(privacy): implement Terms pop-up with translations and API [Clos…

### DIFF
--- a/app/_components/PrivacyBanner.tsx
+++ b/app/_components/PrivacyBanner.tsx
@@ -1,0 +1,256 @@
+"use client";
+import React, { useEffect, useState, memo, useCallback, useMemo } from "react";
+import { Stack, Paper, Link, Button, Switch, CircularProgress } from "@mui/material";
+import { useI18n } from "@/app/_providers/I18nProvider";
+import { useColorScheme } from "@mui/material/styles";
+
+const defaultState = {
+  cookies: true,
+  analytics: true,
+  terms: true,
+};
+
+const STORAGE_KEY = "privacy-consent";
+
+const PrivacyBanner = memo(function PrivacyBanner() {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState(defaultState);
+  const [loading, setLoading] = useState(false);
+  const { dict } = useI18n();
+  const { mode } = useColorScheme();
+  const isDark = mode === "dark";
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (!saved) setOpen(true);
+      else setState(JSON.parse(saved));
+    } catch (error) {
+      console.error("Error reading from localStorage:", error);
+      setOpen(true);
+    }
+  }, []);
+
+  const handleChange = useCallback(
+    (key: keyof typeof defaultState) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setState((prev) => ({ ...prev, [key]: e.target.checked }));
+    },
+    []
+  );
+
+  const handleAccept = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    // Здесь отправляется запрос на сервер
+    try {
+      const response = await fetch("https://example.com", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(state),
+      });
+      if (!response.ok) throw new Error("Ошибка отправки на сервер");
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      setOpen(false);
+    } catch (error) {
+      console.error("Ошибка при отправке данных на сервер:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [state]);
+
+  const handleAcceptAll = useCallback(async () => {
+    setLoading(true);
+    // Здесь отправляется запрос на сервер
+    try {
+      const allTrue = Object.fromEntries(
+        Object.keys(defaultState).map((k) => [k, true])
+      ) as typeof defaultState;
+      const response = await fetch("https://example.com", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(allTrue),
+      });
+      if (!response.ok) throw new Error("Ошибка отправки на сервер");
+      setState(allTrue);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(allTrue));
+      setOpen(false);
+    } catch (error) {
+      console.error("Ошибка при отправке данных на сервер:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const paperStyles = useMemo(() => {
+    const bgPalette = ["var(--mui-palette-secondary-dark)", "var(--mui-palette-secondary-light)"];
+    return {
+      position: "fixed",
+      bottom: { xs: 0, sm: 32 },
+      left: "50%",
+      transform: "translateX(-50%)",
+      zIndex: 2000,
+      minWidth: { xs: "100vw", sm: 260, md: 340, lg: 400 },
+      maxWidth: { xs: "100vw", sm: 340, md: 400, lg: 500 },
+      width: { xs: "100vw", sm: "auto" },
+      p: { xs: 1, sm: 2 },
+      border: `2px dashed ${
+        isDark ? "var(--mui-palette-primary-light)" : "var(--mui-palette-primary-dark)"
+      }`,
+      background: bgPalette[~~!isDark],
+      color: isDark ? "var(--mui-palette-primary-light)" : "var(--mui-palette-text-primary)",
+      borderRadius: { xs: 0, sm: "var(--mui-shape-borderRadius)" },
+      backdropFilter: "blur(36px)",
+      willChange: "transform",
+      boxShadow: { xs: 4, sm: 8 },
+    };
+  }, [isDark]);
+
+  const buttonStyles = useMemo(
+    () => ({
+      accept: {
+        color: isDark ? "var(--mui-palette-primary-light)" : "var(--mui-palette-text-primary)",
+        borderColor: isDark
+          ? "var(--mui-palette-primary-light)"
+          : "var(--mui-palette-primary-dark)",
+        "&:hover": {
+          borderColor: "var(--mui-palette-info-main)",
+          color: "var(--mui-palette-info-main)",
+        },
+      },
+      acceptAll: {
+        background: "var(--mui-palette-info-main)",
+        color: "var(--mui-palette-primary-light)",
+        "&:hover": {
+          background: "var(--mui-palette-info-dark)",
+        },
+      },
+    }),
+    [isDark]
+  );
+
+  if (!open || !dict?.PrivacyBanner) return null;
+
+  return (
+    <Paper sx={paperStyles} elevation={8}>
+      <Stack spacing={2}>
+        {loading ? (
+          <Stack alignItems="center" justifyContent="center" sx={{ minHeight: 160, width: "100%" }}>
+            <CircularProgress size={44} color="info" />
+          </Stack>
+        ) : (
+          <>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              sx={{ flexWrap: { xs: "wrap", sm: "nowrap" } }}
+            >
+              <Link
+                href="/privacy"
+                target="_blank"
+                color="inherit"
+                underline="hover"
+                sx={{ fontSize: { xs: 14, sm: 16 } }}
+              >
+                {dict.PrivacyBanner.cookies}
+              </Link>
+              <Switch
+                checked={state.cookies}
+                onChange={handleChange("cookies")}
+                color="info"
+                size="small"
+              />
+            </Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              sx={{ flexWrap: { xs: "wrap", sm: "nowrap" } }}
+            >
+              <Link
+                href="/analytics"
+                target="_blank"
+                color="inherit"
+                underline="hover"
+                sx={{ fontSize: { xs: 14, sm: 16 } }}
+              >
+                {dict.PrivacyBanner.analytics}
+              </Link>
+              <Switch
+                checked={state.analytics}
+                onChange={handleChange("analytics")}
+                color="info"
+                size="small"
+              />
+            </Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              sx={{ flexWrap: { xs: "wrap", sm: "nowrap" } }}
+            >
+              <Link
+                href="/terms"
+                target="_blank"
+                color="inherit"
+                underline="hover"
+                sx={{ fontSize: { xs: 14, sm: 16 } }}
+              >
+                {dict.PrivacyBanner.terms}
+              </Link>
+              <Switch
+                checked={state.terms}
+                onChange={handleChange("terms")}
+                color="info"
+                size="small"
+              />
+            </Stack>
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              flexWrap={{ xs: "nowrap", sm: "nowrap" }}
+              spacing={2}
+              justifyContent="flex-end"
+              mt={2}
+            >
+              <Button
+                sx={{
+                  ...buttonStyles.acceptAll,
+                  fontSize: { xs: 13, sm: 13, md: 13 },
+                  py: { xs: 0.5, sm: 0.7, md: 0.7 },
+                  minHeight: { xs: 32, sm: 36, md: 36 },
+                  minWidth: { xs: 80, sm: 110, md: 100 },
+                  maxWidth: { xs: "100%", sm: 180 },
+                  width: { xs: "100%", sm: "auto" },
+                  whiteSpace: { xs: "normal", sm: "nowrap" },
+                  order: { xs: 0, sm: 1 },
+                }}
+                variant="contained"
+                onClick={handleAcceptAll}
+              >
+                {dict.PrivacyBanner.acceptAll}
+              </Button>
+              <Button
+                sx={{
+                  ...buttonStyles.accept,
+                  fontSize: { xs: 13, sm: 13, md: 13 },
+                  py: { xs: 0.5, sm: 0.7, md: 0.7 },
+                  minHeight: { xs: 32, sm: 36, md: 36 },
+                  minWidth: { xs: 80, sm: 100, md: 90 },
+                  maxWidth: { xs: "100%", sm: 160 },
+                  width: { xs: "100%", sm: "auto" },
+                  whiteSpace: { xs: "normal", sm: "nowrap" },
+                  order: { xs: 1, sm: 2 },
+                }}
+                variant="outlined"
+                onClick={handleAccept}
+              >
+                {dict.PrivacyBanner.accept}
+              </Button>
+            </Stack>
+          </>
+        )}
+      </Stack>
+    </Paper>
+  );
+});
+
+export { PrivacyBanner };

--- a/app/_components/types.ts
+++ b/app/_components/types.ts
@@ -204,6 +204,14 @@ export interface LegalDictionary {
   Cookies: LegalContent;
 }
 
+export interface PrivacyBannerDict {
+  accept: string;
+  acceptAll: string;
+  cookies: string;
+  analytics: string;
+  terms: string;
+}
+
 export interface AppDictionary extends Dictionary {
   Home: {
     Hero: HeroContent;
@@ -229,4 +237,5 @@ export interface AppDictionary extends Dictionary {
     };
   };
   Legal: LegalDictionary;
+  PrivacyBanner: PrivacyBannerDict;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,200 +1,206 @@
 import * as React from "react";
 import { Roboto } from "next/font/google";
-import { cookies, headers } from "next/headers"
+import { cookies, headers } from "next/headers";
 import Script from "next/script";
 import Image from "next/image";
 import Negotiator from "negotiator";
-import { dictionaries } from "@/dictionaries"
-import { I18nProvider } from "@/app/_providers/I18nProvider"
+import { dictionaries } from "@/dictionaries";
+import { I18nProvider } from "@/app/_providers/I18nProvider";
 import MuiProvider from "@/app/_providers/MuiProvider";
 import "@/app/_components/swiper.css";
 import { ModalFormProvider } from "@/app/_providers/ModalFormProvider";
-import { Metadata } from 'next';
+import { Metadata } from "next";
+import { PrivacyBanner } from "@/app/_components/PrivacyBanner";
 
 const i18n = {
-    defaultLocale: "ru",
-    locales: Object.keys(dictionaries),
+  defaultLocale: "ru",
+  locales: Object.keys(dictionaries),
 };
 
 const roboto = Roboto({
-    weight: ["300", "400", "500", "700"],
-    subsets: ["latin"],
-    display: "swap",
-    variable: "--font-roboto",
+  weight: ["300", "400", "500", "700"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-roboto",
 });
 
 export const metadata: Metadata = {
-    title: "Horizon – Временные ряды и прогнозы",
-    description: "Инструмент для анализа и прогнозирования временных рядов. Time series forecasting and analysis tool.",
-    keywords: [
-        // Английские ключевые слова
-        "time series analysis",
-        "time series forecasting",
-        "forecasting time series",
-        "seasonal decomposition of time series",
-        "trend analysis in time series",
-        "seasonality detection in time series",
-        "temporal patterns detection",
-        "LSTM for time series",
-        "ARIMA time series models",
-        "SARIMA models",
-        "Prophet time series",
-        "predictive models for time series",
-        "demand forecasting models",
-        "time series visualization",
-        "multivariate time series analysis",
-        "univariate time series models",
-        "time series clustering",
-        "feature engineering for time series",
-        "stationarity testing",
-        "time series components analysis",
-        "predictive analytics",
-        "demand forecasting",
-        "business forecasting",
-        "sales forecasting",
-        "inventory forecasting",
-        "financial time series forecasting",
-        "capacity planning",
-        "revenue forecasting",
-        "forecasting in supply chain",
+  title: "Horizon – Временные ряды и прогнозы",
+  description:
+    "Инструмент для анализа и прогнозирования временных рядов. Time series forecasting and analysis tool.",
+  keywords: [
+    // Английские ключевые слова
+    "time series analysis",
+    "time series forecasting",
+    "forecasting time series",
+    "seasonal decomposition of time series",
+    "trend analysis in time series",
+    "seasonality detection in time series",
+    "temporal patterns detection",
+    "LSTM for time series",
+    "ARIMA time series models",
+    "SARIMA models",
+    "Prophet time series",
+    "predictive models for time series",
+    "demand forecasting models",
+    "time series visualization",
+    "multivariate time series analysis",
+    "univariate time series models",
+    "time series clustering",
+    "feature engineering for time series",
+    "stationarity testing",
+    "time series components analysis",
+    "predictive analytics",
+    "demand forecasting",
+    "business forecasting",
+    "sales forecasting",
+    "inventory forecasting",
+    "financial time series forecasting",
+    "capacity planning",
+    "revenue forecasting",
+    "forecasting in supply chain",
 
-        // Русские ключевые слова
-        "анализ временных рядов",
-        "прогнозирование временных рядов",
-        "модели временных рядов",
-        "сезонная декомпозиция временных рядов",
-        "трендовый анализ временных рядов",
-        "выявление сезонности во временных рядах",
-        "выявление закономерностей во временных рядах",
-        "LSTM для временных рядов",
-        "модели ARIMA",
-        "SARIMA модели",
-        "Prophet для временных рядов",
-        "предиктивные модели временных рядов",
-        "прогнозирование спроса по временным рядам",
-        "визуализация временных рядов",
-        "многомерные временные ряды",
-        "одномерные временные ряды",
-        "кластеризация временных рядов",
-        "инженерия признаков для временных рядов",
-        "тестирование стационарности",
-        "анализ компонент временных рядов",
-        "предиктивная аналитика",
-        "прогнозирование спроса",
-        "бизнес-прогнозирование",
-        "прогнозирование продаж",
-        "прогнозирование запасов",
-        "финансовое прогнозирование",
-        "планирование мощностей",
-        "прогнозирование выручки",
-        "прогнозирование в цепочке поставок"
-    ],
-    authors: [{ name: "Horizon Team", url: "https://horizontsd.ru" }],
-    openGraph: {
-        title: "Horizon — Прогнозирование временных рядов",
-        description: "Аналитика и прогноз временных рядов с помощью машинного обучения. Time series forecasting made easy.",
-        url: "https://horizontsd.ru ",
-        siteName: "Horizon",
-        locale: "ru_RU",
-        type: "website",
-    },
-    robots: "index, follow",
+    // Русские ключевые слова
+    "анализ временных рядов",
+    "прогнозирование временных рядов",
+    "модели временных рядов",
+    "сезонная декомпозиция временных рядов",
+    "трендовый анализ временных рядов",
+    "выявление сезонности во временных рядах",
+    "выявление закономерностей во временных рядах",
+    "LSTM для временных рядов",
+    "модели ARIMA",
+    "SARIMA модели",
+    "Prophet для временных рядов",
+    "предиктивные модели временных рядов",
+    "прогнозирование спроса по временным рядам",
+    "визуализация временных рядов",
+    "многомерные временные ряды",
+    "одномерные временные ряды",
+    "кластеризация временных рядов",
+    "инженерия признаков для временных рядов",
+    "тестирование стационарности",
+    "анализ компонент временных рядов",
+    "предиктивная аналитика",
+    "прогнозирование спроса",
+    "бизнес-прогнозирование",
+    "прогнозирование продаж",
+    "прогнозирование запасов",
+    "финансовое прогнозирование",
+    "планирование мощностей",
+    "прогнозирование выручки",
+    "прогнозирование в цепочке поставок",
+  ],
+  authors: [{ name: "Horizon Team", url: "https://horizontsd.ru" }],
+  openGraph: {
+    title: "Horizon — Прогнозирование временных рядов",
+    description:
+      "Аналитика и прогноз временных рядов с помощью машинного обучения. Time series forecasting made easy.",
+    url: "https://horizontsd.ru ",
+    siteName: "Horizon",
+    locale: "ru_RU",
+    type: "website",
+  },
+  robots: "index, follow",
 };
 
 export async function generateStaticParams() {
-    return i18n.locales.map((locale) => ({ lang: locale }));
+  return i18n.locales.map((locale) => ({ lang: locale }));
 }
 
 async function getPreferredLanguages(): Promise<string[]> {
-    const headersList = await headers();
-    if (!headersList.has("accept-language")) {
-        return [i18n.defaultLocale];
-    }
-    const acceptLanguage = headersList.get("accept-language");
-    if (!acceptLanguage) {
-        return [i18n.defaultLocale];
-    }
-    const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
-    return negotiator.languages();
+  const headersList = await headers();
+  if (!headersList.has("accept-language")) {
+    return [i18n.defaultLocale];
+  }
+  const acceptLanguage = headersList.get("accept-language");
+  if (!acceptLanguage) {
+    return [i18n.defaultLocale];
+  }
+  const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
+  return negotiator.languages();
 }
 
 async function getPreferredLanguage(): Promise<string> {
-    let lang = i18n.defaultLocale;
-    const headersList = await headers();
-    if (!headersList.has("accept-language")) {
-        return i18n.defaultLocale;
+  let lang = i18n.defaultLocale;
+  const headersList = await headers();
+  if (!headersList.has("accept-language")) {
+    return i18n.defaultLocale;
+  }
+  const acceptLanguage = headersList.get("accept-language");
+  if (!acceptLanguage) {
+    return i18n.defaultLocale;
+  }
+  const preferredLanguages = await getPreferredLanguages();
+  const shouldAssertLocale = i18n.locales.some((locale) => preferredLanguages.includes(locale));
+  if (shouldAssertLocale) {
+    const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
+    const negotiatedLang = negotiator.language(i18n.locales);
+    if (negotiatedLang) {
+      lang = negotiatedLang;
     }
-    const acceptLanguage = headersList.get("accept-language");
-    if (!acceptLanguage) {
-        return i18n.defaultLocale;
-    }
-    const preferredLanguages = await getPreferredLanguages();
-    const shouldAssertLocale = i18n.locales.some(locale => preferredLanguages.includes(locale));
-    if (shouldAssertLocale) {
-        const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
-        const negotiatedLang = negotiator.language(i18n.locales);
-        if (negotiatedLang) {
-            lang = negotiatedLang;
-        }
-    }
-    return lang;
+  }
+  return lang;
 }
 
 const Metrika = () => (
-    <Script
-        id="yandex-metrika"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-            __html: `(function(m,e,t,r,i,k,a){
+  <Script
+    id="yandex-metrika"
+    strategy="afterInteractive"
+    dangerouslySetInnerHTML={{
+      __html: `(function(m,e,t,r,i,k,a){
                 m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
                 m[i].l=1*new Date();
                 for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
                 k=e.createElement(t),a=e.getElementsByTagName(t)[0],
                 k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
             })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
-            ym(${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}, "init", {accurateTrackBounce:true,clickmap:true,trackLinks:true,webvisor:true});`
-        }}
-    />
-)
+            ym(${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}, "init", {accurateTrackBounce:true,clickmap:true,trackLinks:true,webvisor:true});`,
+    }}
+  />
+);
 
 const MetrikaNoScript = () => (
-    <noscript>
-        <div>
-            <Image
-                alt=""
-                height={1}
-                src={`https://mc.yandex.ru/watch/${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}`}
-                style={{ position: "absolute", left: "-9999px" }}
-                width={1}
-            />
-        </div>
-    </noscript>
+  <noscript>
+    <div>
+      <Image
+        alt=""
+        height={1}
+        src={`https://mc.yandex.ru/watch/${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}`}
+        style={{ position: "absolute", left: "-9999px" }}
+        width={1}
+      />
+    </div>
+  </noscript>
 );
 
 export default async function RootLayout({
-    children,
+  children,
 }: Readonly<{
-    children: React.ReactNode;
+  children: React.ReactNode;
 }>) {
-    const cookieStore = await cookies();
-    let preferredLanguage = await getPreferredLanguage();
-    const cookieLanguage = cookieStore.get("language")?.value;
-    if (cookieLanguage) { preferredLanguage = cookieLanguage; }
-    return (
-        <html lang={preferredLanguage} className={roboto.variable} suppressHydrationWarning>
-            <head>
-                {process.env.NODE_ENV === "production" && <Metrika />}
-            </head>
-            <body>
-                <I18nProvider lang={preferredLanguage}>
-                    <MuiProvider>
-                        <ModalFormProvider opened={false}>
-                            {children}
-                        </ModalFormProvider>
-                    </MuiProvider>
-                </I18nProvider>
-            </body>
-            {process.env.NODE_ENV === "production" && <MetrikaNoScript />}
-        </html>
-    );
+  const cookieStore = await cookies();
+  let preferredLanguage = await getPreferredLanguage();
+  const cookieLanguage = cookieStore.get("language")?.value;
+  if (cookieLanguage) {
+    preferredLanguage = cookieLanguage;
+  }
+  return (
+    <html lang={preferredLanguage} className={roboto.variable} suppressHydrationWarning>
+      <head>{process.env.NODE_ENV === "production" && <Metrika />}</head>
+      <body>
+        <I18nProvider lang={preferredLanguage}>
+          <MuiProvider>
+            <div id="app-root">
+              <ModalFormProvider opened={false}>{children}</ModalFormProvider>
+              <div id="privacy-banner-root">
+                <PrivacyBanner />
+              </div>
+            </div>
+          </MuiProvider>
+        </I18nProvider>
+      </body>
+      {process.env.NODE_ENV === "production" && <MetrikaNoScript />}
+    </html>
+  );
 }

--- a/dictionaries/en-US.json
+++ b/dictionaries/en-US.json
@@ -798,5 +798,13 @@
         }
       ]
     }
+  },
+  "PrivacyBanner": {
+    "cookies": "Cookies",
+    "analytics": "Analytics",
+    "terms": "Terms",
+    "accept": "Accept",
+    "acceptAll": "Accept All",
+    "loading": "Loading..."
   }
 }

--- a/dictionaries/it-IT.json
+++ b/dictionaries/it-IT.json
@@ -801,5 +801,13 @@
         }
       ]
     }
+  },
+  "PrivacyBanner": {
+    "cookies": "Cookie",
+    "analytics": "Analisi",
+    "terms": "Termini",
+    "accept": "Accetta",
+    "acceptAll": "Accetta tutto",
+    "loading": "Caricamento..."
   }
 }

--- a/dictionaries/ru-RU.json
+++ b/dictionaries/ru-RU.json
@@ -806,5 +806,13 @@
         }
       ]
     }
+  },
+  "PrivacyBanner": {
+    "cookies": "Файлы cookie",
+    "analytics": "Аналитика",
+    "terms": "Условия",
+    "accept": "Принять",
+    "acceptAll": "Принять все",
+    "loading": "Загрузка..."
   }
 }


### PR DESCRIPTION
**Closes #168, #172**  

### **Что сделано:**  
1. **UI**: Добавлен pop-up для "Terms of use & cookies" (MUI Dialog + Switch).  
2. **Локализация**: Переводы для pop-up (`en`, `ru`, `it`).  
3. **Состояние**: Сохранение в `localStorage` (настройка через `<PrivacyProvider>`).  
4. **API**: готовая структура с бэкендом для отправки данных.  


![image](https://github.com/user-attachments/assets/fe64636b-3c07-4d13-afa5-53301aacc077)
@ranareinsit 
