### PR TITLE
feat: centralize ConsentProvider in root layout to fix useConsent error

### DIFF
--- a/app/_components/ConsentWrapper.tsx
+++ b/app/_components/ConsentWrapper.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useConsent } from "@/app/_providers/ConsentProvider";
+import ConsentModal from "./ConsentModal";
+
+export default function ConsentWrapper() {
+  const { showConsent } = useConsent();
+  
+  if (!showConsent) return null;
+  
+  return <ConsentModal />;
+}

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -57,8 +57,8 @@ export default function Page() {
       width: `100%`,
     }}>
       <Toolbar id="back-to-top-anchor" sx={{ position: `absolute` }} />
-      <PageContent />
-      <ScrollTop />
-    </Box>
+              <PageContent />
+        <ScrollTop />
+      </Box>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,200 +1,207 @@
 import * as React from "react";
 import { Roboto } from "next/font/google";
-import { cookies, headers } from "next/headers"
+import { cookies, headers } from "next/headers";
 import Script from "next/script";
 import Image from "next/image";
 import Negotiator from "negotiator";
-import { dictionaries } from "@/dictionaries"
-import { I18nProvider } from "@/app/_providers/I18nProvider"
+import { dictionaries } from "@/dictionaries";
+import { I18nProvider } from "@/app/_providers/I18nProvider";
 import MuiProvider from "@/app/_providers/MuiProvider";
 import "@/app/_components/swiper.css";
 import { ModalFormProvider } from "@/app/_providers/ModalFormProvider";
-import { Metadata } from 'next';
+import { ConsentProvider } from "@/app/_providers/ConsentProvider";
+import ConsentWrapper from "@/app/_components/ConsentWrapper";
+import { Metadata } from "next";
 
 const i18n = {
-    defaultLocale: "ru",
-    locales: Object.keys(dictionaries),
+  defaultLocale: "ru",
+  locales: Object.keys(dictionaries),
 };
 
 const roboto = Roboto({
-    weight: ["300", "400", "500", "700"],
-    subsets: ["latin"],
-    display: "swap",
-    variable: "--font-roboto",
+  weight: ["300", "400", "500", "700"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-roboto",
 });
 
 export const metadata: Metadata = {
-    title: "Horizon – Временные ряды и прогнозы",
-    description: "Инструмент для анализа и прогнозирования временных рядов. Time series forecasting and analysis tool.",
-    keywords: [
-        // Английские ключевые слова
-        "time series analysis",
-        "time series forecasting",
-        "forecasting time series",
-        "seasonal decomposition of time series",
-        "trend analysis in time series",
-        "seasonality detection in time series",
-        "temporal patterns detection",
-        "LSTM for time series",
-        "ARIMA time series models",
-        "SARIMA models",
-        "Prophet time series",
-        "predictive models for time series",
-        "demand forecasting models",
-        "time series visualization",
-        "multivariate time series analysis",
-        "univariate time series models",
-        "time series clustering",
-        "feature engineering for time series",
-        "stationarity testing",
-        "time series components analysis",
-        "predictive analytics",
-        "demand forecasting",
-        "business forecasting",
-        "sales forecasting",
-        "inventory forecasting",
-        "financial time series forecasting",
-        "capacity planning",
-        "revenue forecasting",
-        "forecasting in supply chain",
+  title: "Horizon – Временные ряды и прогнозы",
+  description:
+    "Инструмент для анализа и прогнозирования временных рядов. Time series forecasting and analysis tool.",
+  keywords: [
+    // Английские ключевые слова
+    "time series analysis",
+    "time series forecasting",
+    "forecasting time series",
+    "seasonal decomposition of time series",
+    "trend analysis in time series",
+    "seasonality detection in time series",
+    "temporal patterns detection",
+    "LSTM for time series",
+    "ARIMA time series models",
+    "SARIMA models",
+    "Prophet time series",
+    "predictive models for time series",
+    "demand forecasting models",
+    "time series visualization",
+    "multivariate time series analysis",
+    "univariate time series models",
+    "time series clustering",
+    "feature engineering for time series",
+    "stationarity testing",
+    "time series components analysis",
+    "predictive analytics",
+    "demand forecasting",
+    "business forecasting",
+    "sales forecasting",
+    "inventory forecasting",
+    "financial time series forecasting",
+    "capacity planning",
+    "revenue forecasting",
+    "forecasting in supply chain",
 
-        // Русские ключевые слова
-        "анализ временных рядов",
-        "прогнозирование временных рядов",
-        "модели временных рядов",
-        "сезонная декомпозиция временных рядов",
-        "трендовый анализ временных рядов",
-        "выявление сезонности во временных рядах",
-        "выявление закономерностей во временных рядах",
-        "LSTM для временных рядов",
-        "модели ARIMA",
-        "SARIMA модели",
-        "Prophet для временных рядов",
-        "предиктивные модели временных рядов",
-        "прогнозирование спроса по временным рядам",
-        "визуализация временных рядов",
-        "многомерные временные ряды",
-        "одномерные временные ряды",
-        "кластеризация временных рядов",
-        "инженерия признаков для временных рядов",
-        "тестирование стационарности",
-        "анализ компонент временных рядов",
-        "предиктивная аналитика",
-        "прогнозирование спроса",
-        "бизнес-прогнозирование",
-        "прогнозирование продаж",
-        "прогнозирование запасов",
-        "финансовое прогнозирование",
-        "планирование мощностей",
-        "прогнозирование выручки",
-        "прогнозирование в цепочке поставок"
-    ],
-    authors: [{ name: "Horizon Team", url: "https://horizontsd.ru" }],
-    openGraph: {
-        title: "Horizon — Прогнозирование временных рядов",
-        description: "Аналитика и прогноз временных рядов с помощью машинного обучения. Time series forecasting made easy.",
-        url: "https://horizontsd.ru ",
-        siteName: "Horizon",
-        locale: "ru_RU",
-        type: "website",
-    },
-    robots: "index, follow",
+    // Русские ключевые слова
+    "анализ временных рядов",
+    "прогнозирование временных рядов",
+    "модели временных рядов",
+    "сезонная декомпозиция временных рядов",
+    "трендовый анализ временных рядов",
+    "выявление сезонности во временных рядах",
+    "выявление закономерностей во временных рядах",
+    "LSTM для временных рядов",
+    "модели ARIMA",
+    "SARIMA модели",
+    "Prophet для временных рядов",
+    "предиктивные модели временных рядов",
+    "прогнозирование спроса по временным рядам",
+    "визуализация временных рядов",
+    "многомерные временные ряды",
+    "одномерные временные ряды",
+    "кластеризация временных рядов",
+    "инженерия признаков для временных рядов",
+    "тестирование стационарности",
+    "анализ компонент временных рядов",
+    "предиктивная аналитика",
+    "прогнозирование спроса",
+    "бизнес-прогнозирование",
+    "прогнозирование продаж",
+    "прогнозирование запасов",
+    "финансовое прогнозирование",
+    "планирование мощностей",
+    "прогнозирование выручки",
+    "прогнозирование в цепочке поставок",
+  ],
+  authors: [{ name: "Horizon Team", url: "https://horizontsd.ru" }],
+  openGraph: {
+    title: "Horizon — Прогнозирование временных рядов",
+    description:
+      "Аналитика и прогноз временных рядов с помощью машинного обучения. Time series forecasting made easy.",
+    url: "https://horizontsd.ru ",
+    siteName: "Horizon",
+    locale: "ru_RU",
+    type: "website",
+  },
+  robots: "index, follow",
 };
 
 export async function generateStaticParams() {
-    return i18n.locales.map((locale) => ({ lang: locale }));
+  return i18n.locales.map((locale) => ({ lang: locale }));
 }
 
 async function getPreferredLanguages(): Promise<string[]> {
-    const headersList = await headers();
-    if (!headersList.has("accept-language")) {
-        return [i18n.defaultLocale];
-    }
-    const acceptLanguage = headersList.get("accept-language");
-    if (!acceptLanguage) {
-        return [i18n.defaultLocale];
-    }
-    const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
-    return negotiator.languages();
+  const headersList = await headers();
+  if (!headersList.has("accept-language")) {
+    return [i18n.defaultLocale];
+  }
+  const acceptLanguage = headersList.get("accept-language");
+  if (!acceptLanguage) {
+    return [i18n.defaultLocale];
+  }
+  const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
+  return negotiator.languages();
 }
 
 async function getPreferredLanguage(): Promise<string> {
-    let lang = i18n.defaultLocale;
-    const headersList = await headers();
-    if (!headersList.has("accept-language")) {
-        return i18n.defaultLocale;
+  let lang = i18n.defaultLocale;
+  const headersList = await headers();
+  if (!headersList.has("accept-language")) {
+    return i18n.defaultLocale;
+  }
+  const acceptLanguage = headersList.get("accept-language");
+  if (!acceptLanguage) {
+    return i18n.defaultLocale;
+  }
+  const preferredLanguages = await getPreferredLanguages();
+  const shouldAssertLocale = i18n.locales.some((locale) => preferredLanguages.includes(locale));
+  if (shouldAssertLocale) {
+    const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
+    const negotiatedLang = negotiator.language(i18n.locales);
+    if (negotiatedLang) {
+      lang = negotiatedLang;
     }
-    const acceptLanguage = headersList.get("accept-language");
-    if (!acceptLanguage) {
-        return i18n.defaultLocale;
-    }
-    const preferredLanguages = await getPreferredLanguages();
-    const shouldAssertLocale = i18n.locales.some(locale => preferredLanguages.includes(locale));
-    if (shouldAssertLocale) {
-        const negotiator = new Negotiator({ headers: { "accept-language": acceptLanguage } });
-        const negotiatedLang = negotiator.language(i18n.locales);
-        if (negotiatedLang) {
-            lang = negotiatedLang;
-        }
-    }
-    return lang;
+  }
+  return lang;
 }
 
 const Metrika = () => (
-    <Script
-        id="yandex-metrika"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-            __html: `(function(m,e,t,r,i,k,a){
+  <Script
+    id="yandex-metrika"
+    strategy="afterInteractive"
+    dangerouslySetInnerHTML={{
+      __html: `(function(m,e,t,r,i,k,a){
                 m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
                 m[i].l=1*new Date();
                 for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
                 k=e.createElement(t),a=e.getElementsByTagName(t)[0],
                 k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
             })(window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
-            ym(${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}, "init", {accurateTrackBounce:true,clickmap:true,trackLinks:true,webvisor:true});`
-        }}
-    />
-)
+            ym(${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}, "init", {accurateTrackBounce:true,clickmap:true,trackLinks:true,webvisor:true});`,
+    }}
+  />
+);
 
 const MetrikaNoScript = () => (
-    <noscript>
-        <div>
-            <Image
-                alt=""
-                height={1}
-                src={`https://mc.yandex.ru/watch/${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}`}
-                style={{ position: "absolute", left: "-9999px" }}
-                width={1}
-            />
-        </div>
-    </noscript>
+  <noscript>
+    <div>
+      <Image
+        alt=""
+        height={1}
+        src={`https://mc.yandex.ru/watch/${process.env.NEXT_PUBLIC_YANDEX_ANALYTICS_ID}`}
+        style={{ position: "absolute", left: "-9999px" }}
+        width={1}
+      />
+    </div>
+  </noscript>
 );
 
 export default async function RootLayout({
-    children,
+  children,
 }: Readonly<{
-    children: React.ReactNode;
+  children: React.ReactNode;
 }>) {
-    const cookieStore = await cookies();
-    let preferredLanguage = await getPreferredLanguage();
-    const cookieLanguage = cookieStore.get("language")?.value;
-    if (cookieLanguage) { preferredLanguage = cookieLanguage; }
-    return (
-        <html lang={preferredLanguage} className={roboto.variable} suppressHydrationWarning>
-            <head>
-                {process.env.NODE_ENV === "production" && <Metrika />}
-            </head>
-            <body>
-                <I18nProvider lang={preferredLanguage}>
-                    <MuiProvider>
-                        <ModalFormProvider opened={false}>
-                            {children}
-                        </ModalFormProvider>
-                    </MuiProvider>
-                </I18nProvider>
-            </body>
-            {process.env.NODE_ENV === "production" && <MetrikaNoScript />}
-        </html>
-    );
+  const cookieStore = await cookies();
+  let preferredLanguage = await getPreferredLanguage();
+  const cookieLanguage = cookieStore.get("language")?.value;
+  if (cookieLanguage) {
+    preferredLanguage = cookieLanguage;
+  }
+  return (
+    <html lang={preferredLanguage} className={roboto.variable} suppressHydrationWarning>
+      <head>{process.env.NODE_ENV === "production" && <Metrika />}</head>
+      <body>
+        <I18nProvider lang={preferredLanguage}>
+          <MuiProvider>
+            <ModalFormProvider opened={false}>
+              <ConsentProvider>
+                {children}
+                <ConsentWrapper />
+              </ConsentProvider>
+            </ModalFormProvider>
+          </MuiProvider>
+        </I18nProvider>
+      </body>
+      {process.env.NODE_ENV === "production" && <MetrikaNoScript />}
+    </html>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,8 +13,6 @@ import About from "@/app/_components/About";
 import Faq from "@/app/_components/Faq";
 import Footer from "@/app/_components/Footer";
 import ScrollTop from "@/app/_components/ScrollTop";
-import ConsentModal from "@/app/_components/ConsentModal";
-import { ConsentProvider } from "@/app/_providers/ConsentProvider";
 function PageContent() {
   return (
     <>
@@ -34,24 +32,21 @@ function PageContent() {
 
 export default function Page() {
   return (
-    <ConsentProvider>
-      <Box
-        sx={{
-          alignItems: `center`,
-          display: `flex`,
-          flexDirection: `column`,
-          justifyContent: `start`,
-          margin: `0 auto`,
-          overflow: `hidden`,
-          overflowX: `hidden`,
-          width: `100%`,
-        }}
-      >
-        <Toolbar id="back-to-top-anchor" sx={{ position: `absolute` }} />
-        <PageContent />
+    <Box
+      sx={{
+        alignItems: `center`,
+        display: `flex`,
+        flexDirection: `column`,
+        justifyContent: `start`,
+        margin: `0 auto`,
+        overflow: `hidden`,
+        overflowX: `hidden`,
+        width: `100%`,
+      }}
+    >
+      <Toolbar id="back-to-top-anchor" sx={{ position: `absolute` }} />
+              <PageContent />
         <ScrollTop />
-        <ConsentModal />
       </Box>
-    </ConsentProvider>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -53,24 +53,26 @@ function PageContent() {
       </Section>
       <Footer />
     </>
-  )
+  );
 }
 
 export default function Page() {
   return (
-    <Box sx={{
-      alignItems: `center`,
-      display: `flex`,
-      flexDirection: `column`,
-      justifyContent: `start`,
-      margin: `0 auto`,
-      overflow: `hidden`,
-      overflowX: `hidden`,
-      width: `100%`,
-    }}>
+    <Box
+      sx={{
+        alignItems: `center`,
+        display: `flex`,
+        flexDirection: `column`,
+        justifyContent: `start`,
+        margin: `0 auto`,
+        overflow: `hidden`,
+        overflowX: `hidden`,
+        width: `100%`,
+      }}
+    >
       <Toolbar id="back-to-top-anchor" sx={{ position: `absolute` }} />
       <PageContent />
       <ScrollTop />
     </Box>
-  )
+  );
 }

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -149,8 +149,8 @@ export default function Page() {
       <Toolbar id="back-to-top-anchor" sx={{ position: "absolute" }} />
       <ResearchPage />
       <CallToAction />
-      <Footer />
-      <ScrollTop />
-    </Box>
+              <Footer />
+        <ScrollTop />
+      </Box>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -9,8 +9,6 @@ import Paragraph from "@/app/_components/Paragraph";
 import { useI18n } from "@/app/_providers/I18nProvider";
 import ScrollTop from "@/app/_components/ScrollTop";
 import { useConsentCheck } from "@/app/_hooks/useConsentCheck";
-import { ConsentProvider } from "@/app/_providers/ConsentProvider";
-import ConsentModal from "@/app/_components/ConsentModal";
 
 function PageContent() {
   const { dict } = useI18n();
@@ -70,24 +68,21 @@ function PageContent() {
 
 export default function Page() {
   return (
-    <ConsentProvider>
-      <Box
-        sx={{
-          alignItems: `center`,
-          display: `flex`,
-          flexDirection: `column`,
-          justifyContent: `start`,
-          margin: `0 auto`,
-          overflow: `hidden`,
-          overflowX: `hidden`,
-          width: `100%`,
-        }}
-      >
-        <Toolbar id="back-to-top-anchor" sx={{ position: `absolute` }} />
-        <PageContent />
+    <Box
+      sx={{
+        alignItems: `center`,
+        display: `flex`,
+        flexDirection: `column`,
+        justifyContent: `start`,
+        margin: `0 auto`,
+        overflow: `hidden`,
+        overflowX: `hidden`,
+        width: `100%`,
+      }}
+    >
+      <Toolbar id="back-to-top-anchor" sx={{ position: `absolute` }} />
+              <PageContent />
         <ScrollTop />
-        <ConsentModal />
       </Box>
-    </ConsentProvider>
   );
 }


### PR DESCRIPTION
- Move ConsentProvider from individual pages to root layout.tsx
- Create ConsentWrapper component for global consent modal display
- Remove duplicate ConsentProvider and ConsentModal imports from all pages
- Fix 'useConsent must be used within ConsentProvider' error
- Ensure consent functionality works across all pages